### PR TITLE
fix default error handling middleware

### DIFF
--- a/app/templates/server.js
+++ b/app/templates/server.js
@@ -41,7 +41,7 @@ const app = express()
 
   }))
 
-  .use(function(request, response) {
+  .use(function(err, request, response, next) {
     response.status(500).sendfile(__dirname + '/public/unrecoverable-error.html');
   })
 ;


### PR DESCRIPTION
express js uses the arity of the function to decide if a middleware is a true error handler that can handle next(error) calls